### PR TITLE
Conditionally compile X11 support

### DIFF
--- a/gtk-input-context/client-gtk/client-gtk.pro
+++ b/gtk-input-context/client-gtk/client-gtk.pro
@@ -14,6 +14,10 @@ QMAKE_CFLAGS_DEBUG+=-Wno-error=deprecated-declarations
 
 DEFINES += G_LOG_DOMAIN=\\\"Maliit\\\"
 
+x11 {
+    DEFINES += HAVE_X11
+}
+
 HEADERS += \
     ../client-gtk/client-imcontext-gtk.h \
     ../client-gtk/qt-gtk-translate.h \

--- a/gtk-input-context/client-gtk3/client-gtk3.pro
+++ b/gtk-input-context/client-gtk3/client-gtk3.pro
@@ -14,6 +14,10 @@ QMAKE_CFLAGS_DEBUG+=-Wno-error=deprecated-declarations
 
 DEFINES += G_LOG_DOMAIN=\\\"Maliit\\\"
 
+x11 {
+    DEFINES += HAVE_X11
+}
+
 HEADERS += \
     ../client-gtk/client-imcontext-gtk.h \
     ../client-gtk/qt-gtk-translate.h \

--- a/maliit-inputcontext-gtk.pro
+++ b/maliit-inputcontext-gtk.pro
@@ -7,6 +7,7 @@ include(./config.pri)
         \\n\\t PREFIX : Install prefix (default: /usr) \
         \\n\\t {BIN,LIB,INCLUDE,DOC}DIR : Install prefix for specific types of files \
         \\nRecognised CONFIG flags: \
+        \\n\\t x11 : Compile with X11 support \
         \\n\\t disable-gtk-cache-update : Do not update GTK2/3 input method caches (used for packaging) \
         \\n\\t local-install : Install everything underneath PREFIX, nothing to system directories reported by GTK+, Qt, DBus etc. \
         \\nInfluential environment variables: \


### PR DESCRIPTION
Add "x11" CONFIG option. We also check to see if we're running on X before trying to get an XID.
